### PR TITLE
Fix report generator text overflow

### DIFF
--- a/ui.r
+++ b/ui.r
@@ -153,79 +153,82 @@ ui <- navbarPage(
         tabPanel(
             "Fisher Catch",
             div(
-                class = "content-container-grid grid-report",
+                class = "content-container-parent",
                 div(
-                    class = "content-box",
-                    h2("Fisher Catch Project Reports"),
-                    p(dummy_text[1])
-                ),
-                div(
-                    class = "content-container-grid grid-generator",
+                    class = "content-container-grid grid-report",
                     div(
-                        class = "input-box",
-                        h3("Upload Data"),
-                        tags$ol(
-                            class = "content-list",
-                            tags$li(
-                                class = "input-list",
-                                "Choose Time Period",
-                                div(
-                                    class = "input-list-content",
-                                    prettyRadioButtons("period_catchproj",
-                                        label = NULL,
-                                        choices = c("One Season", "One Year", "Multiple Seasons", "Multiple Years"), selected = "One Season", inline = TRUE
-                                    )
-                                )
-                            ),
-                            hr(),
-                            tags$li(
-                                class = "input-list",
-                                "Choose CSV File",
-                                div(
-                                    class = "input-list-content",
-                                    fileInput(
-                                        "upload_catchproj_1per",
-                                        label = NULL,
-                                        multiple = FALSE,
-                                        accept = c(
-                                            "text/csv",
-                                            "text/comma-separated-values,text/plain",
-                                            ".csv"
-                                        )
-                                    )
-                                )
-                            ),
-                            hr(),
-                            tags$li(
-                                class = "input-list",
-                                "Validate Data",
-                                div(
-                                    class = "input-list-content",
-                                    actionButton("validate_catchproj_1per", "Perform Validation")
-                                )
-                            )
-                        )
+                        class = "content-box",
+                        h2("Fisher Catch Project Reports"),
+                        p(dummy_text[1])
                     ),
                     div(
-                        class = "input-box",
-                        h3("Customize Report"),
-                        tags$ol(
-                            class = "content-list",
-                            tags$li(
-                                class = "input-list",
-                                "Add Inputs",
-                                div(
-                                    class = "input-list-content",
-                                    textInput("name", "Your Name: ", value = "")
+                        class = "content-container grid-generator",
+                        div(
+                            class = "input-box",
+                            h3("Upload Data"),
+                            tags$ol(
+                                class = "content-list",
+                                tags$li(
+                                    class = "input-list",
+                                    "Choose Time Period",
+                                    div(
+                                        class = "input-list-content",
+                                        prettyRadioButtons("period_catchproj",
+                                            label = NULL,
+                                            choices = c("One Season", "One Year", "Multiple Seasons", "Multiple Years"), selected = "One Season", inline = TRUE
+                                        )
+                                    )
+                                ),
+                                hr(),
+                                tags$li(
+                                    class = "input-list",
+                                    "Choose CSV File",
+                                    div(
+                                        class = "input-list-content",
+                                        fileInput(
+                                            "upload_catchproj_1per",
+                                            label = NULL,
+                                            multiple = FALSE,
+                                            accept = c(
+                                                "text/csv",
+                                                "text/comma-separated-values,text/plain",
+                                                ".csv"
+                                            )
+                                        )
+                                    )
+                                ),
+                                hr(),
+                                tags$li(
+                                    class = "input-list",
+                                    "Validate Data",
+                                    div(
+                                        class = "input-list-content",
+                                        actionButton("validate_catchproj_1per", "Perform Validation")
+                                    )
                                 )
-                            ),
-                            hr(),
-                            tags$li(
-                                class = "input-list",
-                                "Generate Report",
-                                div(
-                                    class = "input-list-content",
-                                    downloadButton("report_catchproj_1per", "Generate")
+                            )
+                        ),
+                        div(
+                            class = "input-box",
+                            h3("Customize Report"),
+                            tags$ol(
+                                class = "content-list",
+                                tags$li(
+                                    class = "input-list",
+                                    "Add Inputs",
+                                    div(
+                                        class = "input-list-content",
+                                        textInput("name", "Your Name: ", value = "")
+                                    )
+                                ),
+                                hr(),
+                                tags$li(
+                                    class = "input-list",
+                                    "Generate Report",
+                                    div(
+                                        class = "input-list-content",
+                                        downloadButton("report_catchproj_1per", "Generate")
+                                    )
                                 )
                             )
                         )
@@ -244,83 +247,83 @@ ui <- navbarPage(
                         h2("LAMP Reports"),
                         p(datatype_text[2])
                     ),
-                ),
-                div(
-                    class = "content-container grid-generator",
                     div(
-                        class = "input-box",
-                        h3("Upload Data"),
-                        tags$ol(
-                            class = "content-list",
-                            tags$li(
-                                class = "input-list",
-                                "Choose Datatype",
-                                div(
-                                    class = "input-list-content",
-                                    prettyRadioButtons("datatype_lamp", label = NULL, choices = c("Conch", "General LAMP"), selected = "Conch", inline = TRUE)
-                                )
-                            ),
-                            hr(),
-                            tags$li(
-                                class = "input-list",
-                                "Choose Time Period",
-                                div(
-                                    class = "input-list-content",
-                                    prettyRadioButtons("period_lamp",
-                                        label = NULL,
-                                        choices = c("One Period", "Multiple Periods"), selected = "One Period", inline = TRUE
+                        class = "content-container grid-generator",
+                        div(
+                            class = "input-box",
+                            h3("Upload Data"),
+                            tags$ol(
+                                class = "content-list",
+                                tags$li(
+                                    class = "input-list",
+                                    "Choose Datatype",
+                                    div(
+                                        class = "input-list-content",
+                                        prettyRadioButtons("datatype_lamp", label = NULL, choices = c("Conch", "General LAMP"), selected = "Conch", inline = TRUE)
                                     )
-                                )
-                            ),
-                            hr(),
-                            tags$li(
-                                class = "input-list",
-                                "Choose CSV File",
-                                div(
-                                    class = "input-list-content",
-                                    fileInput(
-                                        "upload_lamp_1per",
-                                        label = NULL,
-                                        multiple = FALSE,
-                                        accept = c(
-                                            "text/csv",
-                                            "text/comma-separated-values,text/plain",
-                                            ".csv"
+                                ),
+                                hr(),
+                                tags$li(
+                                    class = "input-list",
+                                    "Choose Time Period",
+                                    div(
+                                        class = "input-list-content",
+                                        prettyRadioButtons("period_lamp",
+                                            label = NULL,
+                                            choices = c("One Period", "Multiple Periods"), selected = "One Period", inline = TRUE
                                         )
                                     )
-                                )
-                            ),
-                            hr(),
-                            tags$li(
-                                class = "input-list",
-                                "Validate Data",
-                                div(
-                                    class = "input-list-content",
-                                    actionButton("validate_lamp_1per", "Perform Validation")
+                                ),
+                                hr(),
+                                tags$li(
+                                    class = "input-list",
+                                    "Choose CSV File",
+                                    div(
+                                        class = "input-list-content",
+                                        fileInput(
+                                            "upload_lamp_1per",
+                                            label = NULL,
+                                            multiple = FALSE,
+                                            accept = c(
+                                                "text/csv",
+                                                "text/comma-separated-values,text/plain",
+                                                ".csv"
+                                            )
+                                        )
+                                    )
+                                ),
+                                hr(),
+                                tags$li(
+                                    class = "input-list",
+                                    "Validate Data",
+                                    div(
+                                        class = "input-list-content",
+                                        actionButton("validate_lamp_1per", "Perform Validation")
+                                    )
                                 )
                             )
-                        )
-                    ),
-                    div(
-                        class = "input-box",
-                        h3("Customize Report"),
-                        tags$ol(
-                            class = "content-list",
-                            tags$li(
-                                class = "input-list",
-                                "Add Inputs",
-                                div(
-                                    class = "input-list-content",
-                                    textInput("name", "Your Name: ", value = "")
-                                )
-                            ),
-                            hr(),
-                            tags$li(
-                                class = "input-list",
-                                "Generate Report",
-                                div(
-                                    class = "input-list-content",
-                                    downloadButton("report_lamp_1per", "Generate")
+                        ),
+                        div(
+                            class = "input-box",
+                            h3("Customize Report"),
+                            tags$ol(
+                                class = "content-list",
+                                tags$li(
+                                    class = "input-list",
+                                    "Add Inputs",
+                                    div(
+                                        class = "input-list-content",
+                                        textInput("name", "Your Name: ", value = "")
+                                    )
+                                ),
+                                hr(),
+                                tags$li(
+                                    class = "input-list",
+                                    "Generate Report",
+                                    div(
+                                        class = "input-list-content",
+                                        downloadButton("report_lamp_1per", "Generate")
+                                    )
                                 )
                             )
                         )
@@ -338,81 +341,81 @@ ui <- navbarPage(
                         class = "content-box",
                         h2("SPAG Reports"),
                         p(datatype_text[3])
-                    )
-                ),
-                div(
-                    class = "content-container grid-generator",
-                    div(
-                        class = "input-box",
-                        h3("Upload Data"),
-                        tags$ol(
-                            class = "content-list",
-                            tags$li(
-                                class = "input-list",
-                                "Choose Datatype",
-                                div(
-                                    class = "input-list-content",
-                                    prettyRadioButtons("datatype_spag", label = NULL, choices = c("Visual Census", "Laser Data"), selected = "Visual Census", inline = TRUE)
-                                )
-                            ),
-                            hr(),
-                            tags$li(
-                                class = "input-list",
-                                "Choose Time Period",
-                                div(
-                                    class = "input-list-content",
-                                    prettyRadioButtons("period_spag", label = NULL, choices = c("One Year", "Multiple Years"), selected = "One Year", inline = TRUE)
-                                )
-                            ),
-                            hr(),
-                            tags$li(
-                                class = "input-list",
-                                "Choose CSV File",
-                                div(
-                                    class = "input-list-content",
-                                    fileInput(
-                                        "upload_spag_1per",
-                                        label = NULL,
-                                        multiple = FALSE,
-                                        accept = c(
-                                            "text/csv",
-                                            "text/comma-separated-values,text/plain",
-                                            ".csv"
-                                        )
-                                    )
-                                )
-                            ),
-                            hr(),
-                            tags$li(
-                                class = "input-list",
-                                "Validate Data",
-                                div(
-                                    class = "input-list-content",
-                                    actionButton("validate_spag_1per", "Perform Validation")
-                                )
-                            )
-                        )
                     ),
                     div(
-                        class = "input-box",
-                        h3("Customize Report"),
-                        tags$ol(
-                            class = "content-list",
-                            tags$li(
-                                class = "input-list",
-                                "Add Inputs",
-                                div(
-                                    class = "input-list-content",
-                                    textInput("name", "Your Name: ", value = "")
+                        class = "content-container grid-generator",
+                        div(
+                            class = "input-box",
+                            h3("Upload Data"),
+                            tags$ol(
+                                class = "content-list",
+                                tags$li(
+                                    class = "input-list",
+                                    "Choose Datatype",
+                                    div(
+                                        class = "input-list-content",
+                                        prettyRadioButtons("datatype_spag", label = NULL, choices = c("Visual Census", "Laser Data"), selected = "Visual Census", inline = TRUE)
+                                    )
+                                ),
+                                hr(),
+                                tags$li(
+                                    class = "input-list",
+                                    "Choose Time Period",
+                                    div(
+                                        class = "input-list-content",
+                                        prettyRadioButtons("period_spag", label = NULL, choices = c("One Year", "Multiple Years"), selected = "One Year", inline = TRUE)
+                                    )
+                                ),
+                                hr(),
+                                tags$li(
+                                    class = "input-list",
+                                    "Choose CSV File",
+                                    div(
+                                        class = "input-list-content",
+                                        fileInput(
+                                            "upload_spag_1per",
+                                            label = NULL,
+                                            multiple = FALSE,
+                                            accept = c(
+                                                "text/csv",
+                                                "text/comma-separated-values,text/plain",
+                                                ".csv"
+                                            )
+                                        )
+                                    )
+                                ),
+                                hr(),
+                                tags$li(
+                                    class = "input-list",
+                                    "Validate Data",
+                                    div(
+                                        class = "input-list-content",
+                                        actionButton("validate_spag_1per", "Perform Validation")
+                                    )
                                 )
-                            ),
-                            hr(),
-                            tags$li(
-                                class = "input-list",
-                                "Generate Report",
-                                div(
-                                    class = "input-list-content",
-                                    downloadButton("report_spag_1per", "Generate")
+                            )
+                        ),
+                        div(
+                            class = "input-box",
+                            h3("Customize Report"),
+                            tags$ol(
+                                class = "content-list",
+                                tags$li(
+                                    class = "input-list",
+                                    "Add Inputs",
+                                    div(
+                                        class = "input-list-content",
+                                        textInput("name", "Your Name: ", value = "")
+                                    )
+                                ),
+                                hr(),
+                                tags$li(
+                                    class = "input-list",
+                                    "Generate Report",
+                                    div(
+                                        class = "input-list-content",
+                                        downloadButton("report_spag_1per", "Generate")
+                                    )
                                 )
                             )
                         )

--- a/www/styles.css
+++ b/www/styles.css
@@ -152,7 +152,6 @@ label {
   padding: 0 15vw;
   position: absolute;
   right: 0;
-  top: 250px;
   width: 100vw;
 }
 .grid-home,


### PR DESCRIPTION
The Widths of the inputs for the report generators are not as wide as before. They look orderly still, let me know if they should be put back to their original widths.
