### PR TITLE
Fix input name not being re-checked when re-validating on the same tab

### DIFF
--- a/server.r
+++ b/server.r
@@ -477,19 +477,24 @@ server <- function(input, output, session) {
             confirmButtonText = "I Understand", confirmButtonCol = "#cde9f0", type = "info", size = "s"
         )
         enableCustomization("fisheries_1per")
+        nameLengthCheck(input$fisheries_1per_name, "fisheries_1per")
     })
+
     observeEvent(input$validate_fisheries_multiper, {
         shinyalert("Notice!", "Validation has not been implemented for Fisheries Multi-Year as of yet!",
             confirmButtonText = "I Understand", confirmButtonCol = "#cde9f0", type = "info", size = "s"
         )
         enableCustomization("fisheries_multiper")
+        nameLengthCheck(input$fisheries_multiper_name, "fisheries_multiper")
     })
+
     source("validation/validation_observers/validate_fisher_observer_1per.r", local = TRUE)
     observeEvent(input$validate_fisher_multiper, {
         shinyalert("Notice!", "Validation has not been implemented for Fisher Project Multi-Year as of yet!",
             confirmButtonText = "I Understand", confirmButtonCol = "#cde9f0", type = "info", size = "s"
         )
         enableCustomization("fisher_multiper")
+        nameLengthCheck(input$fisher_multiper_name, "fisher_multiper")
     })
     source("validation/validation_observers/validate_lamp_observer_1per.r", local = TRUE)
     source("validation/validation_observers/validate_lamp_observer_multiper.r", local = TRUE)
@@ -498,12 +503,14 @@ server <- function(input, output, session) {
             confirmButtonText = "I Understand", confirmButtonCol = "#cde9f0", type = "info", size = "s"
         )
         enableCustomization("spag_1per")
+        nameLengthCheck(input$spag_1per_name, "spag_1per")
     })
     observeEvent(input$validate_spag_multiper, {
         shinyalert("Notice!", "Validation has not been implemented for SPAG Multi-Year as of yet!",
             confirmButtonText = "I Understand", confirmButtonCol = "#cde9f0", type = "info", size = "s"
         )
         enableCustomization("spag_multiper")
+        nameLengthCheck(input$spag_multiper_name, "spag_multiper")
     })
 
     # Observe report generate buttons

--- a/validation/validation_observers/validate_fisher_observer_1per.r
+++ b/validation/validation_observers/validate_fisher_observer_1per.r
@@ -48,13 +48,15 @@ observeEvent(input$validate_fisher_1per, {
             if (validation_passed || nchar(validation_message) == 0) {
                 shinyalert("Success!", "Validation Successful!",
                     confirmButtonText = "Great!", confirmButtonCol = "#00AE46", type = "success", size = "s",
-                    enableCustomization("fisher_1per")
+                    enableCustomization("fisher_1per"),
+                    nameLengthCheck(input$fisher_1per_name, "fisher_1per")
                 )
             } else {
                 shinyalert("Attention!",
                     text = validation_message,
                     confirmButtonText = "I Understand", confirmButtonCol = "#FFA400", type = "warning", size = "m", html = TRUE,
-                    enableCustomization("fisher_1per")
+                    enableCustomization("fisher_1per"),
+                    nameLengthCheck(input$fisher_1per_name, "fisher_1per")
                 )
             }
         }

--- a/validation/validation_observers/validate_lamp_observer_1per.r
+++ b/validation/validation_observers/validate_lamp_observer_1per.r
@@ -109,13 +109,15 @@ observeEvent(input$validate_lamp_1per, {
                 if (validation_passed || nchar(validation_message) == 0) {
                     shinyalert("Success!", "Validation Successful!",
                         confirmButtonText = "Great!", confirmButtonCol = "#00AE46", type = "success", size = "s",
-                        enableCustomization("lamp_1per")
+                        enableCustomization("lamp_1per"),
+                        nameLengthCheck(input$lamp_1per_name, "lamp_1per")
                     )
                 } else {
                     shinyalert("Attention!",
                         text = validation_message,
                         confirmButtonText = "I Understand", confirmButtonCol = "#FFA400", type = "warning", size = "m", html = TRUE,
-                        enableCustomization("lamp_1per")
+                        enableCustomization("lamp_1per"),
+                        nameLengthCheck(input$fisher_1per_name, "fisher_1per")
                     )
                 }
             }

--- a/validation/validation_observers/validate_lamp_observer_multiper.r
+++ b/validation/validation_observers/validate_lamp_observer_multiper.r
@@ -504,6 +504,7 @@ observeEvent(input$validate_lamp_multiper, {
         }
         if (all(validation_status)) {
             enableCustomization("lamp_multiper")
+            nameLengthCheck(input$lamp_multiper_name, "lamp_multiper")
         }
     }
 })


### PR DESCRIPTION
Input name length is now also checked whenever file is validated to ensure subsequent reuploads/valudations can proceed to customization step 2 granted the name is valid.