### PR TITLE
Make styling changes to tabs

### DIFF
--- a/server_helpers.r
+++ b/server_helpers.r
@@ -41,6 +41,7 @@ removeConfirmation <- function(reportType) {
 showLoaderBar <- function(reportType, session) {
     shinyjs::show(paste0(reportType, "_loader"))
     shinyjs::hide(paste0("report_", reportType))
+    shinyjs::hide(paste0("figures_", reportType))
     for (i in seq(0, 70, by = 10)) {
         Sys.sleep(0.1)
         session$sendCustomMessage("updateLoader", list(reportType = reportType, percentage = i))
@@ -50,6 +51,7 @@ hideLoaderBar <- function(reportType, session) {
     session$sendCustomMessage("updateLoader", list(reportType = reportType, percentage = 100))
     Sys.sleep(0.2)
     shinyjs::show(paste0("report_", reportType))
+    shinyjs::show(paste0("figures_", reportType))
     shinyjs::hide(paste0(reportType, "_loader"))
     session$sendCustomMessage("resetLoader", list(reportType = reportType))
 }

--- a/ui.r
+++ b/ui.r
@@ -1754,6 +1754,56 @@ ui <- navbarPage(
             )
         )
     ),
+    navbarMenu(
+        "Data",
+        tabPanel(
+            "Templates",
+            div(
+                class = "content-container-parent",
+                div(
+                    class = "content-container-grid grid-report",
+                    div(
+                        class = "content-box",
+                        h2("Data Templates"),
+                        p(tab_text[1]),
+                        br(),
+                        p(tab_text[2]),
+                        br(),
+                        p(tab_text[3])
+                    ),
+                    div(
+                        class = "data-template-table",
+                        uiOutput("template_list_table")
+                    )
+                )
+            )
+        ),
+        tabPanel(
+            "Historical",
+            div(
+                class = "content-container-parent",
+                div(
+                    class = "content-container-grid grid-report",
+                    div(
+                        class = "content-box",
+                        p("For a bank of existing standardized historic data, visit the Data Bank below:"),
+                        br()
+                    ),
+                    div(
+                        class = "content-container",
+                        div(
+                            class = "external-link-button",
+                            a(
+                                href = link_text[10],
+                                target = "_blank",
+                                h1("Data Bank")
+                            )
+                        )
+                    )
+                )
+            )
+        )
+    ),
     tabPanel(
         "Manual",
         div(
@@ -1789,44 +1839,6 @@ ui <- navbarPage(
                                 target = "_blank",
                                 h1("Data Validation Documentation")
                             )
-                        )
-                    )
-                )
-            )
-        )
-    ),
-    tabPanel(
-        "Data Templates",
-        div(
-            class = "content-container-parent",
-            div(
-                class = "content-container-grid grid-report",
-                div(
-                    class = "content-box",
-                    h2("Data Templates"),
-                    p(tab_text[1]),
-                    br(),
-                    p(tab_text[2]),
-                    br(),
-                    p(tab_text[3])
-                ),
-                div(
-                    class = "data-template-table",
-                    uiOutput("template_list_table")
-                ),
-                div(
-                    class = "content-box",
-                    p("For a bank of existing standardized historic data, visit the Data Bank below:"),
-                    br()
-                ),
-                div(
-                    class = "content-container",
-                    div(
-                        class = "external-link-button",
-                        a(
-                            href = link_text[10],
-                            target = "_blank",
-                            h1("Data Bank")
                         )
                     )
                 )

--- a/www/styles.css
+++ b/www/styles.css
@@ -550,3 +550,15 @@ label {
 .dl-bttn-container > .input-list-content {
   padding: 5px;
 }
+
+/* Styles for Smaller Screens < 1000px */
+@media only screen and (max-width: 1100px) {
+  .version-header {
+    top:20px;
+  }
+}
+@media only screen and (max-width: 1025px) {
+  .header-logo {
+    display:none;
+  }
+}


### PR DESCRIPTION
Fix "Download Figures" not being hidden while plot download progress bar is showing.
Add CSS to reposition version # and hide logo when on smaller screens.
Change "Data Templates" tab to be "Data" with subtabs "Templates" and "Historical".
Change order of navber tabs (Swap positions of "Manual" and "Data" nav tabs) .