### PR TITLE
Fix lamp multiper name length check

### DIFF
--- a/server.r
+++ b/server.r
@@ -316,7 +316,7 @@ server <- function(input, output, session) {
         }
     })
 
-    # Observe Multiyear Upload
+    # Observe Multiper Upload
     observeEvent(input$upload_fisheries_multiper1, {
         enableUpload("fisheries_multiper2")
         disableCustomization("fisheries_multiper")
@@ -443,7 +443,6 @@ server <- function(input, output, session) {
         disableUpload("lamp_multiper4")
         disableUploadRemoveBttn("lamp_multiper3")
         removeConfirmation("lamp_multiper3")
-        lamp_multiper3_flag(FALSE)
     })
     observeEvent(input$remove_lamp_multiper4_bttn, {
         reset("upload_lamp_multiper4")
@@ -451,7 +450,6 @@ server <- function(input, output, session) {
         disableUploadRemoveBttn("lamp_multiper4")
         enableUploadRemoveBttn("lamp_multiper3")
         removeConfirmation("lamp_multiper4")
-        lamp_multiper4_flag(FALSE)
     })
     observeEvent(input$remove_spag_multiper3_bttn, {
         reset("upload_spag_multiper3")

--- a/validation/validation_observers/validate_lamp_observer_1per.r
+++ b/validation/validation_observers/validate_lamp_observer_1per.r
@@ -32,15 +32,17 @@ observeEvent(input$validate_lamp_1per, {
                 }
                 if (validation_passed || nchar(validation_message) == 0) {
                     shinyalert("Success!", "Validation Successful!",
-                        confirmButtonText = "Great!", confirmButtonCol = "#00AE46", type = "success", size = "s",
-                        enableCustomization("lamp_1per")
+                        confirmButtonText = "Great!", confirmButtonCol = "#00AE46", type = "success", size = "s"
                     )
+                    enableCustomization("lamp_1per")
+                    nameLengthCheck(input$lamp_1per_name, "lamp_1per")
                 } else {
                     shinyalert("Attention!",
                         text = validation_message,
-                        confirmButtonText = "I Understand", confirmButtonCol = "#FFA400", type = "warning", size = "m", html = TRUE,
-                        enableCustomization("lamp_1per")
+                        confirmButtonText = "I Understand", confirmButtonCol = "#FFA400", type = "warning", size = "m", html = TRUE
                     )
+                    enableCustomization("lamp_1per")
+                    nameLengthCheck(input$lamp_1per_name, "lamp_1per")
                 }
             }
         }
@@ -108,17 +110,17 @@ observeEvent(input$validate_lamp_1per, {
                 }
                 if (validation_passed || nchar(validation_message) == 0) {
                     shinyalert("Success!", "Validation Successful!",
-                        confirmButtonText = "Great!", confirmButtonCol = "#00AE46", type = "success", size = "s",
-                        enableCustomization("lamp_1per"),
-                        nameLengthCheck(input$lamp_1per_name, "lamp_1per")
+                        confirmButtonText = "Great!", confirmButtonCol = "#00AE46", type = "success", size = "s"
                     )
+                    enableCustomization("lamp_1per")
+                    nameLengthCheck(input$lamp_1per_name, "lamp_1per")
                 } else {
                     shinyalert("Attention!",
                         text = validation_message,
-                        confirmButtonText = "I Understand", confirmButtonCol = "#FFA400", type = "warning", size = "m", html = TRUE,
-                        enableCustomization("lamp_1per"),
-                        nameLengthCheck(input$fisher_1per_name, "fisher_1per")
+                        confirmButtonText = "I Understand", confirmButtonCol = "#FFA400", type = "warning", size = "m", html = TRUE
                     )
+                    enableCustomization("lamp_1per")
+                    nameLengthCheck(input$lamp_1per_name, "lamp_1per")
                 }
             }
         }

--- a/validation/validation_observers/validate_lamp_observer_multiper.r
+++ b/validation/validation_observers/validate_lamp_observer_multiper.r
@@ -188,6 +188,7 @@ observeEvent(input$validate_lamp_multiper, {
 
         if (all(validation_status)) {
             enableCustomization("lamp_multiper")
+            nameLengthCheck(input$lamp_multiper_name, "lamp_multiper")
         }
 
         # Validate LAMP General multiper


### PR DESCRIPTION
Fix LAMP Multiper tab not checking name length on validate/revalidation for conch datatype.
Update LAMP 1per customization enabling was in the wrong spot in validate_lamp_observer_1per.r